### PR TITLE
Integrate external policy tag validator.

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -152,6 +152,8 @@ GENERATED_FILES += hmp-commands.h hmp-commands-info.h
 
 endif # CONFIG_SOFTMMU
 
+obj-y += policy_validator.o
+
 # Workaround for http://gcc.gnu.org/PR55489, see configure.
 %/translate.o: QEMU_CFLAGS += $(TRANSLATE_OPT_CFLAGS)
 

--- a/configure
+++ b/configure
@@ -463,6 +463,9 @@ supported_os="no"
 bogus_os="no"
 malloc_trim=""
 
+validator_include=""
+validator_lib=""
+
 # parse CC options first
 for opt do
   optarg=$(expr "x$opt" : 'x[^=]*=\(.*\)')
@@ -1382,6 +1385,10 @@ for opt do
   ;;
   --disable-git-update) git_update=no
   ;;
+  --with-validator-lib=*) validator_lib="$optarg"
+  ;;
+  --with-validator-include=*) validator_include="$optarg"
+  ;;
   *)
       echo "ERROR: unknown option $opt"
       echo "Try '$0 --help' for more information"
@@ -1389,6 +1396,14 @@ for opt do
   ;;
   esac
 done
+
+if test "${validator_lib+set}" = set; then :
+   QEMU_LDFLAGS="-L$validator_lib -lrv32-renode-validator $QEMU_LDFLAGS"
+fi
+
+if test "${validator_include+set}" = set; then :
+   QEMU_CFLAGS="-I$validator_include $QEMU_CFLAGS"
+fi
 
 if test "$vhost_user" = ""; then
     if test "$mingw32" = "yes"; then
@@ -1555,6 +1570,9 @@ Advanced options (experts only):
                            xen pv domain builder
   --enable-debug-stack-usage
                            track the maximum stack usage of stacks created by qemu_alloc_stack
+
+  --with-validator-lib     Set the external tag validator library path
+  --with-validator-include Set the external tag validator include path
 
 Optional features, enabled with --enable-FEATURE and
 disabled with --disable-FEATURE, default is enabled if available:
@@ -7158,6 +7176,13 @@ fi
 if test "$TARGET_ARCH" = "s390x" -a "$target_softmmu" = "yes"  -a "$ARCH" = "s390x" -a "$kvm" = "yes"; then
     if ld_has --s390-pgste ; then
         ldflags="-Wl,--s390-pgste $ldflags"
+    fi
+fi
+
+# Currently the external validator only supports riscv32
+if test "$target_name" = "riscv32"; then :
+    if test "${validator_include+set}" = set; then :
+        cflags="-DENABLE_VALIDATOR $cflags"
     fi
 fi
 

--- a/include/policy_validator.h
+++ b/include/policy_validator.h
@@ -1,0 +1,29 @@
+#ifndef POLICY_VALIDATOR_H
+#define POLICY_VALIDATOR_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#ifdef ENABLE_VALIDATOR
+#include "qemu_interface.h"
+#endif
+
+typedef struct PolicyValidatorConfig {
+    bool enabled;
+    const char* policy_path;
+    const char* tag_info_file;
+} PolicyValidatorConfig;
+
+
+void set_policy_validator_enabled(bool val);
+bool policy_validator_enabled(void);
+
+void set_policy_validator_policy_path(const char* path);
+void set_policy_validator_tag_info_file(const char* file);
+
+const char* get_policy_validator_policy_path(void);
+const char* get_policy_validator_tag_info_file(void);
+
+void set_policy_validator_metadata(void);
+bool policy_validator_commit(void);
+
+#endif /* POLICY_VALIDATOR_H */

--- a/policy_validator.c
+++ b/policy_validator.c
@@ -1,0 +1,55 @@
+#include "policy_validator.h"
+#include <stdio.h>
+
+static PolicyValidatorConfig policy_validator;
+
+bool policy_validator_enabled(void)
+{
+    return policy_validator.enabled;
+}
+
+void set_policy_validator_enabled(bool val)
+{
+    policy_validator.enabled = val;
+}
+
+void set_policy_validator_policy_path(const char* path)
+{
+    printf("set policy dir path to%s\n", path);
+    policy_validator.policy_path = path;
+}
+
+void set_policy_validator_tag_info_file(const char* file)
+{
+    printf("set policy tag file to%s\n", file);
+    policy_validator.tag_info_file = file;
+}
+
+const char* get_policy_validator_policy_path(void)
+{
+    return policy_validator.policy_path;
+}
+
+const char* get_policy_validator_tag_info_file(void)
+{
+    return policy_validator.tag_info_file;
+}
+
+void set_policy_validator_metadata(void)
+{
+#ifdef ENABLE_VALIDATOR
+    if (policy_validator_enabled())
+        e_v_set_metadata(policy_validator.policy_path,
+                         policy_validator.tag_info_file);
+#endif
+}
+
+
+bool policy_validator_commit(void)
+{
+#ifdef ENABLE_VALIDATOR
+    if (policy_validator_enabled())
+        return e_v_commit();
+#endif
+    return true;
+}

--- a/qemu-options.hx
+++ b/qemu-options.hx
@@ -4408,6 +4408,15 @@ e.g to launch a SEV guest
 
 ETEXI
 
+DEF("policy-validator-cfg", HAS_ARG, QEMU_OPTION_policy_validator_cfg,
+    "-policy-validator-cfg policy-path=<dir>,tag-info-file=<file>\n"
+    "                setup the policy <dir> and tag-info-file <file> for policy metadata.\n",
+    QEMU_ARCH_RISCV)
+STEXI
+@item -policy-validator-cfg policy-path=@var{dir},tag-info-file=@var{file}
+@findex -policy-validator-cfg
+Policy dir and metadata tag info file.
+ETEXI
 
 HXCOMM This is the last statement. Insert new options before this line!
 STEXI

--- a/target/riscv/translate.c
+++ b/target/riscv/translate.c
@@ -28,8 +28,12 @@
 
 #include "exec/translator.h"
 #include "exec/log.h"
+#include "qemu-options.h"
+#include "sysemu/sysemu.h"
 
 #include "instmap.h"
+
+#include "policy_validator.h"
 
 /* global register indices */
 static TCGv cpu_gpr[32], cpu_pc;
@@ -73,6 +77,29 @@ static const int tcg_memop_lookup[8] = {
 #else
 #define CASE_OP_32_64(X) case X
 #endif
+
+//Policy validator functions that are dependent on target length
+void policy_validator_set_callbacks(target_ulong (*reg_reader)(uint32_t),
+                                    target_ulong (*mem_reader)(target_ulong));
+bool policy_validator_validate(target_ulong pc, uint32_t insn);
+
+bool policy_validator_validate(target_ulong pc, uint32_t insn)
+{
+#ifdef ENABLE_VALIDATOR
+    if (policy_validator_enabled())
+        return e_v_validate(pc, insn);
+#endif
+    return true;
+}
+
+void policy_validator_set_callbacks(target_ulong (*reg_reader)(uint32_t),
+                                    target_ulong (*mem_reader)(target_ulong))
+{
+#ifdef ENABLE_VALIDATOR
+    if (policy_validator_enabled())
+        e_v_set_callbacks(reg_reader, mem_reader);
+#endif
+}
 
 static void generate_exception(DisasContext *ctx, int excp)
 {
@@ -1849,6 +1876,14 @@ static void riscv_tr_translate_insn(DisasContextBase *dcbase, CPUState *cpu)
     CPURISCVState *env = cpu->env_ptr;
 
     ctx->opcode = cpu_ldl_code(env, ctx->base.pc_next);
+    uint32_t pc = ctx->base.pc_next;
+    if(pc != 0x1000 && pc != 0x1004) { //reset ROM
+        if(!policy_validator_validate(pc, ctx->opcode)) {
+            qemu_log("Validator Validation Failed at PC=0x%x\n", pc);
+            exit(1);
+        }
+        policy_validator_commit();
+    }
     decode_opc(env, ctx);
     ctx->base.pc_next = ctx->pc_succ_insn;
 
@@ -1905,6 +1940,26 @@ void gen_intermediate_code(CPUState *cs, TranslationBlock *tb)
     translator_loop(&riscv_tr_ops, &ctx.base, cs, tb);
 }
 
+
+static inline target_ulong policy_validator_reg_reader(uint32_t reg_num)
+#if TARGET_LONG_BITS == 32
+{
+    if(reg_num == 0) return 0;
+
+    TCGTemp *a = tcgv_i32_temp(cpu_gpr[reg_num]);
+    return a->val;
+}
+#elif TARGET_LONG_BITS == 64
+{
+    if(reg_num == 0) return 0;
+
+    TCGTemp *a = tcgv_i64_temp(cpu_gpr[reg_num]);
+    return a->val;
+}
+#else
+#error unsupported
+#endif
+
 void riscv_translate_init(void)
 {
     int i;
@@ -1929,4 +1984,7 @@ void riscv_translate_init(void)
                              "load_res");
     load_val = tcg_global_mem_new(cpu_env, offsetof(CPURISCVState, load_val),
                              "load_val");
+
+    set_policy_validator_metadata();
+    policy_validator_set_callbacks(policy_validator_reg_reader, NULL);
 }

--- a/vl.c
+++ b/vl.c
@@ -130,6 +130,8 @@ int main(int argc, char **argv)
 #include "qapi/qmp/qerror.h"
 #include "sysemu/iothread.h"
 
+#include "policy_validator.h"
+
 #define MAX_VIRTIO_CONSOLES 1
 
 static const char *data_dir[16];
@@ -517,6 +519,25 @@ static QemuOptsList qemu_fw_cfg_opts = {
             .name = "string",
             .type = QEMU_OPT_STRING,
             .help = "Sets content of the blob to be inserted from a string",
+        },
+        { /* end of list */ }
+    },
+};
+
+static QemuOptsList qemu_policy_validator_cfg_opts = {
+    .name = "policy-validator-cfg",
+    .implied_opt_name = "enable",
+    .head = QTAILQ_HEAD_INITIALIZER(qemu_policy_validator_cfg_opts.head),
+    .desc = {
+        {
+            .name = "enable",
+            .type = QEMU_OPT_BOOL,
+        }, {
+            .name = "policy-path",
+            .type = QEMU_OPT_STRING,
+        }, {
+            .name = "tag-info-file",
+            .type = QEMU_OPT_STRING,
         },
         { /* end of list */ }
     },
@@ -2974,6 +2995,7 @@ int main(int argc, char **argv, char **envp)
     qemu_add_opts(&qemu_icount_opts);
     qemu_add_opts(&qemu_semihosting_config_opts);
     qemu_add_opts(&qemu_fw_cfg_opts);
+    qemu_add_opts(&qemu_policy_validator_cfg_opts);
     module_call_init(MODULE_INIT_OPTS);
 
     runstate_init();
@@ -3923,6 +3945,18 @@ int main(int argc, char **argv, char **envp)
                 if (vmstate_dump_file == NULL) {
                     error_report("open %s: %s", optarg, strerror(errno));
                     exit(1);
+                }
+                break;
+            case QEMU_OPTION_policy_validator_cfg:
+                opts = qemu_opts_parse_noisily(qemu_find_opts("policy-validator-cfg"),
+                                               optarg, true);
+
+                if (opts != NULL) {
+                    set_policy_validator_enabled(qemu_opt_get_bool(opts, "enable",
+                                                                   true));
+
+                    set_policy_validator_policy_path(qemu_opt_get(opts, "policy-path"));
+                    set_policy_validator_tag_info_file(qemu_opt_get(opts, "tag-info-file"));
                 }
                 break;
             case QEMU_OPTION_nodefconfig:


### PR DESCRIPTION
This patch adds arguments to set the tag policy directory and metadata tag file.
It also adds support for validating riscv32 instructions.
Once an external validator supports riscv64, it should work if ENABLE_VALIDATOR
is now defined in the configure script for riscv64.