### PR TITLE
PIPE Usability Updates

### DIFF
--- a/policy_validator.c
+++ b/policy_validator.c
@@ -110,6 +110,7 @@ void policy_validator_set_mem_watch(uint64_t addr)
 void policy_validator_rule_cache_stats(void)
 {
 #ifdef ENABLE_VALIDATOR
-    e_v_rule_cache_stats();
+    if (policy_validator_enabled())
+        e_v_rule_cache_stats();
 #endif
 }

--- a/policy_validator.c
+++ b/policy_validator.c
@@ -39,7 +39,7 @@ bool policy_validator_commit(void)
     if (policy_validator_enabled())
         return e_v_commit();
 #endif
-    return true;
+    return false;
 }
 
 void policy_validator_violation_msg(char* dest, int n)

--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -27,6 +27,7 @@
 #include "qemu/error-report.h"
 #include "hw/qdev-properties.h"
 #include "migration/vmstate.h"
+#include "policy_validator.h"
 
 /* RISC-V CPU definitions */
 
@@ -408,6 +409,13 @@ static void riscv_cpu_realize(DeviceState *dev, Error **errp)
         }
 
         set_misa(env, RVXLEN | target_misa);
+    }
+
+    /* Set validator extension if requested */
+    if (policy_validator_enabled()) {
+       set_misa(env, env->misa | RVP);
+
+       qemu_printf("\nEnabling Validator Extension\n");
     }
 
     riscv_cpu_register_gdb_regs_for_features(cs);

--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -418,6 +418,13 @@ static void riscv_cpu_realize(DeviceState *dev, Error **errp)
        qemu_printf("\nEnabling Validator Extension\n");
     }
 
+    if (!cpu->cfg.ext_f) {
+       set_misa(env, env->misa & ~RVF);
+
+       qemu_printf("\nForce Disable Floating Point Extension\n");
+    }
+
+
     riscv_cpu_register_gdb_regs_for_features(cs);
 
     qemu_init_vcpu(cs);

--- a/target/riscv/cpu.h
+++ b/target/riscv/cpu.h
@@ -67,6 +67,7 @@
 #define RVC RV('C')
 #define RVS RV('S')
 #define RVU RV('U')
+#define RVP RV('P')
 
 /* S extension denotes that Supervisor mode exists, however it is possible
    to have a core that support S mode but does not have an MMU and there


### PR DESCRIPTION
Make the PIPE enhanced QEMU easier to use by fixing the validator disable option, adding a custom PIPE RISC-V extension, and allowing manipulation of RISC-V extensions that currently cause problems.

These changes make it easier to change QEMU and software behavior at runtime instead of having to compile multiple tools/applications for each configuration.