### PR TITLE
Move validator calls to IR layer

### DIFF
--- a/Makefile.target
+++ b/Makefile.target
@@ -175,7 +175,7 @@ generated-files-y += config-devices.h
 
 endif # CONFIG_SOFTMMU
 
-obj-y += policy_validator.o
+obj-y += policy_validator.o policy-helper.o
 
 dummy := $(call unnest-vars,,obj-y)
 all-obj-y := $(obj-y)

--- a/accel/tcg/cpu-exec.c
+++ b/accel/tcg/cpu-exec.c
@@ -37,7 +37,6 @@
 #endif
 #include "sysemu/cpus.h"
 #include "sysemu/replay.h"
-#include "policy_validator.h"
 
 /* -icount align implementation. */
 
@@ -405,7 +404,7 @@ static inline TranslationBlock *tb_find(CPUState *cpu,
     uint32_t flags;
 
     tb = tb_lookup__cpu_state(cpu, &pc, &cs_base, &flags, cf_mask);
-    if (tb == NULL || policy_validator_enabled()) {
+    if (tb == NULL) {
         mmap_lock();
         tb = tb_gen_code(cpu, pc, cs_base, flags, cf_mask);
         mmap_unlock();

--- a/include/policy_validator.h
+++ b/include/policy_validator.h
@@ -21,6 +21,7 @@ void set_policy_validator_cfg_path(const char* path);
 const char* get_policy_validator_cfg_path(void);
 
 void set_policy_validator_metadata(void);
+void policy_validator_init(void);
 bool policy_validator_commit(void);
 
 void policy_validator_violation_msg(char* dest, int n);

--- a/policy-helper.c
+++ b/policy-helper.c
@@ -15,6 +15,8 @@
 #ifdef ENABLE_VALIDATOR
 static bool skipped_commit = false;
 
+extern CPURISCVState* policy_validator_hack_env;
+
 void helper_validator_validate(CPURISCVState *env, target_ulong pc, uint32_t opcode)
 {
    /* PC altering instructions will skip the commit helper. */
@@ -25,6 +27,7 @@ void helper_validator_validate(CPURISCVState *env, target_ulong pc, uint32_t opc
    }
    skipped_commit = true;
 
+   policy_validator_hack_env = env;
    if (!e_v_validate(pc, opcode)) {
       char *msg = g_malloc(1024);
       policy_validator_violation_msg(msg, 1024);

--- a/policy-helper.c
+++ b/policy-helper.c
@@ -1,0 +1,34 @@
+/*
+ * RISC-V Policy Validator FPU Emulation Helpers for QEMU.
+ *
+ */
+
+#include "qemu/osdep.h"
+#include "qemu/log.h"
+#include "cpu.h"
+#include "qemu/main-loop.h"
+#include "exec/exec-all.h"
+#include "exec/helper-proto.h"
+
+#include "policy_validator.h"
+
+#ifdef ENABLE_VALIDATOR
+void helper_validator_validate(CPURISCVState *env, target_ulong pc, uint32_t opcode)
+{
+   if (!e_v_validate(pc, opcode)) {
+      char *msg = g_malloc(1024);
+      policy_validator_violation_msg(msg, 1024);
+      qemu_log("%s", msg);
+      qemu_log("MSG: End test.\n");
+      g_free(msg);
+      exit(1);
+   }
+}
+
+void helper_validator_commit(CPURISCVState *env)
+{
+   if (e_v_commit()) {
+      riscv_raise_exception(env, EXCP_DEBUG, GETPC());
+   }
+}
+#endif

--- a/policy_validator.c
+++ b/policy_validator.c
@@ -32,16 +32,6 @@ void set_policy_validator_metadata(void)
 #endif
 }
 
-
-bool policy_validator_commit(void)
-{
-#ifdef ENABLE_VALIDATOR
-    if (policy_validator_enabled())
-        return e_v_commit();
-#endif
-    return false;
-}
-
 void policy_validator_violation_msg(char* dest, int n)
 {
 #ifdef ENABLE_VALIDATOR

--- a/policy_validator.c
+++ b/policy_validator.c
@@ -1,7 +1,18 @@
+#include "qemu/osdep.h"
+#include "cpu.h"
 #include "policy_validator.h"
 #include <stdio.h>
 
 static PolicyValidatorConfig policy_validator;
+
+CPURISCVState* policy_validator_hack_env;
+
+static inline target_ulong policy_validator_reg_reader(uint32_t reg_num)
+{
+    if(reg_num == 0) return 0;
+
+    return policy_validator_hack_env->gpr[reg_num];
+}
 
 bool policy_validator_enabled(void)
 {
@@ -29,6 +40,17 @@ void set_policy_validator_metadata(void)
 #ifdef ENABLE_VALIDATOR
     if (policy_validator_enabled())
         e_v_set_metadata(policy_validator.validator_cfg_path);
+#endif
+}
+
+void policy_validator_init(void)
+{
+#ifdef ENABLE_VALIDATOR
+    if (policy_validator_enabled()) {
+        e_v_set_metadata(policy_validator.validator_cfg_path);
+        e_v_set_callbacks(policy_validator_reg_reader,
+                          NULL);
+    }
 #endif
 }
 

--- a/target/riscv/helper.h
+++ b/target/riscv/helper.h
@@ -1,3 +1,8 @@
+#ifdef ENABLE_VALIDATOR
+DEF_HELPER_3(validator_validate, void, env, tl, i32)
+DEF_HELPER_1(validator_commit, void, env)
+#endif
+
 /* Exceptions */
 DEF_HELPER_2(raise_exception, noreturn, env, i32)
 

--- a/target/riscv/translate.c
+++ b/target/riscv/translate.c
@@ -88,19 +88,6 @@ static inline bool has_ext(DisasContext *ctx, uint32_t ext)
     return ctx->misa & ext;
 }
 
-//Policy validator functions that are dependent on target length
-void policy_validator_set_callbacks(target_ulong (*reg_reader)(uint32_t),
-                                    target_ulong (*mem_reader)(target_ulong));
-
-void policy_validator_set_callbacks(target_ulong (*reg_reader)(uint32_t),
-                                    target_ulong (*mem_reader)(target_ulong))
-{
-#ifdef ENABLE_VALIDATOR
-    if (policy_validator_enabled())
-        e_v_set_callbacks(reg_reader, mem_reader);
-#endif
-}
-
 static void generate_exception(DisasContext *ctx, int excp)
 {
     tcg_gen_movi_tl(cpu_pc, ctx->base.pc_next);
@@ -808,15 +795,10 @@ static bool riscv_tr_breakpoint_check(DisasContextBase *dcbase, CPUState *cpu,
     return true;
 }
 
-static CPURISCVState* policy_validator_hack_env;
-
 static void riscv_tr_translate_insn(DisasContextBase *dcbase, CPUState *cpu)
 {
     DisasContext *ctx = container_of(dcbase, DisasContext, base);
     CPURISCVState *env = cpu->env_ptr;
-
-    policy_validator_hack_env = env;
-
 
     ctx->opcode = cpu_ldl_code(env, ctx->base.pc_next);
 
@@ -908,13 +890,6 @@ void gen_intermediate_code(CPUState *cs, TranslationBlock *tb, int max_insns)
 }
 
 
-static inline target_ulong policy_validator_reg_reader(uint32_t reg_num)
-{
-    if(reg_num == 0) return 0;
-
-    return policy_validator_hack_env->gpr[reg_num];
-}
-
 void riscv_translate_init(void)
 {
     int i;
@@ -940,6 +915,5 @@ void riscv_translate_init(void)
     load_val = tcg_global_mem_new(cpu_env, offsetof(CPURISCVState, load_val),
                              "load_val");
 
-    set_policy_validator_metadata();
-    policy_validator_set_callbacks(policy_validator_reg_reader, NULL);
+    policy_validator_init();
 }


### PR DESCRIPTION
This improves emulation speed and hopefully fixes some odd behavior that was occurring with the validator in the translation layer.