### PR TITLE
64 bit simulation support

### DIFF
--- a/Makefile.isp
+++ b/Makefile.isp
@@ -4,7 +4,7 @@
 
 ISP_PREFIX ?= /opt/isp/
 
-CONFIGURE_OPTIONS := --target-list=riscv32-linux-user,riscv32-softmmu,riscv64-linux-user,riscv64-softmmu
+CONFIGURE_OPTIONS := --target-list=riscv32-softmmu,riscv64-softmmu
 CONFIGURE_OPTIONS += --with-validator-lib=$(ISP_PREFIX)/lib
 CONFIGURE_OPTIONS += --with-validator-include=$(ISP_PREFIX)/include
 CONFIGURE_OPTIONS += --prefix=$(ISP_PREFIX)

--- a/Makefile.target
+++ b/Makefile.target
@@ -175,7 +175,9 @@ generated-files-y += config-devices.h
 
 endif # CONFIG_SOFTMMU
 
+ifdef CONFIG_VALIDATOR
 obj-y += policy_validator.o policy-helper.o
+endif # CONFIG_VALIDATOR
 
 dummy := $(call unnest-vars,,obj-y)
 all-obj-y := $(obj-y)

--- a/Makefile.target
+++ b/Makefile.target
@@ -176,6 +176,8 @@ generated-files-y += config-devices.h
 endif # CONFIG_SOFTMMU
 
 ifdef CONFIG_VALIDATOR
+LIBS := $(libs_validator) $(LIBS)
+
 obj-y += policy_validator.o policy-helper.o
 endif # CONFIG_VALIDATOR
 

--- a/configure
+++ b/configure
@@ -6316,7 +6316,6 @@ echo_version() {
 
 if test -n "$validator_lib"; then :
    QEMU_LDFLAGS="-L$validator_lib $QEMU_LDFLAGS"
-   LIBS="-lrv32-renode-validator $LIBS"
 fi
 
 if test -n "$validator_include}"; then :
@@ -7623,6 +7622,9 @@ case "$target_name" in
     mttcg=yes
     gdb_xml_files="riscv-32bit-cpu.xml riscv-32bit-fpu.xml riscv-32bit-csr.xml"
     target_compiler=$cross_cc_riscv32
+    policy_engine_lib=rv32-renode-validator
+    libs_validator="-l$policy_engine_lib"
+    echo "libs_validator=$libs_validator" >> $config_target_mak
   ;;
   riscv64)
     TARGET_BASE_ARCH=riscv
@@ -7630,6 +7632,9 @@ case "$target_name" in
     mttcg=yes
     gdb_xml_files="riscv-64bit-cpu.xml riscv-64bit-fpu.xml riscv-64bit-csr.xml"
     target_compiler=$cross_cc_riscv64
+    policy_engine_lib=rv64-renode-validator
+    libs_validator="-l$policy_engine_lib"
+    echo "libs_validator=$libs_validator" >> $config_target_mak
   ;;
   sh4|sh4eb)
     TARGET_ARCH=sh4

--- a/configure
+++ b/configure
@@ -7326,6 +7326,11 @@ fi
 if test "$sheepdog" = "yes" ; then
   echo "CONFIG_SHEEPDOG=y" >> $config_host_mak
 fi
+if test -n "$validator_lib"; then :
+  if test -n "$validator_include}"; then :
+    echo "CONFIG_VALIDATOR=y" >> $config_host_mak
+  fi
+fi
 
 if test "$tcg_interpreter" = "yes"; then
   QEMU_INCLUDES="-iquote \$(SRC_PATH)/tcg/tci $QEMU_INCLUDES"

--- a/configure
+++ b/configure
@@ -7902,11 +7902,8 @@ if test "$TARGET_ARCH" = "s390x" && test "$target_softmmu" = "yes" && \
     fi
 fi
 
-# Currently the external validator only supports riscv32
-if test "$target_name" = "riscv32"; then :
-    if test -n "$validator_include"; then :
-        cflags="-DENABLE_VALIDATOR $cflags"
-    fi
+if test -n "$validator_include"; then
+    cflags="-DENABLE_VALIDATOR $cflags"
 fi
 
 echo "LDFLAGS+=$ldflags" >> $config_target_mak

--- a/include/policy_validator.h
+++ b/include/policy_validator.h
@@ -4,11 +4,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 #ifdef ENABLE_VALIDATOR
-
-#if defined(TARGET_RISCV64)
-#define RV64_VALIDATOR
-#endif
-
 #include "qemu_interface.h"
 #endif
 

--- a/include/policy_validator.h
+++ b/include/policy_validator.h
@@ -4,6 +4,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 #ifdef ENABLE_VALIDATOR
+
+#if defined(TARGET_RISCV64)
+#define RV64_VALIDATOR
+#endif
+
 #include "qemu_interface.h"
 #endif
 

--- a/policy-helper.c
+++ b/policy-helper.c
@@ -28,7 +28,7 @@ void helper_validator_validate(CPURISCVState *env, target_ulong pc, uint32_t opc
    skipped_commit = true;
 
    policy_validator_hack_env = env;
-   if (!e_v_validate(pc, opcode)) {
+   if (!e_v_validate((uint64_t)pc, opcode)) {
       char *msg = g_malloc(1024);
       policy_validator_violation_msg(msg, 1024);
       qemu_log("%s", msg);

--- a/policy_validator.c
+++ b/policy_validator.c
@@ -7,11 +7,11 @@ static PolicyValidatorConfig policy_validator;
 
 CPURISCVState* policy_validator_hack_env;
 
-static inline target_ulong policy_validator_reg_reader(uint32_t reg_num)
+static inline uint64_t policy_validator_reg_reader(uint32_t reg_num)
 {
     if(reg_num == 0) return 0;
 
-    return policy_validator_hack_env->gpr[reg_num];
+    return (uint64_t)policy_validator_hack_env->gpr[reg_num];
 }
 
 bool policy_validator_enabled(void)

--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -191,6 +191,15 @@ static void rv64imacu_nommu_cpu_init(Object *obj)
     set_feature(env, RISCV_FEATURE_PMP);
 }
 
+static void rv64gcu_nommu_cpu_init(Object *obj)
+{
+    CPURISCVState *env = &RISCV_CPU(obj)->env;
+    set_misa(env, RV64 | RVI | RVM | RVA | RVF | RVD | RVC);
+    set_priv_version(env, PRIV_VERSION_1_10_0);
+    set_resetvec(env, DEFAULT_RSTVEC);
+    set_feature(env, RISCV_FEATURE_PMP);
+}
+
 #endif
 
 static ObjectClass *riscv_cpu_class_by_name(const char *cpu_model)
@@ -580,7 +589,7 @@ static const TypeInfo riscv_cpu_type_infos[] = {
     DEFINE_CPU(TYPE_RISCV_CPU_RV32GCSU_V1_10_0, rv32gcsu_priv1_10_0_cpu_init)
 #elif defined(TARGET_RISCV64)
     DEFINE_CPU(TYPE_RISCV_CPU_BASE64,           riscv_base64_cpu_init),
-    DEFINE_CPU(TYPE_RISCV_CPU_SIFIVE_E51,       rv64imacu_nommu_cpu_init),
+    DEFINE_CPU(TYPE_RISCV_CPU_SIFIVE_E51,       rv64gcu_nommu_cpu_init),
     DEFINE_CPU(TYPE_RISCV_CPU_SIFIVE_U54,       rv64gcsu_priv1_10_0_cpu_init),
     /* Deprecated */
     DEFINE_CPU(TYPE_RISCV_CPU_RV64IMACU_NOMMU,  rv64imacu_nommu_cpu_init),


### PR DESCRIPTION
This change updates QEMU to use a different validator library for 32 and 64 bit.  It no longer uses a define to include different validator APIs.