### PR TITLE
Add code to handle virtual memory addresses

### DIFF
--- a/policy-helper.c
+++ b/policy-helper.c
@@ -16,10 +16,12 @@
 static bool skipped_commit = false;
 
 extern CPURISCVState* policy_validator_hack_env;
+extern CPUState* policy_validator_hack_cpu_state;
 
-void helper_validator_validate(CPURISCVState *env, target_ulong pc, uint32_t opcode)
+void helper_validator_validate(CPURISCVState *env, target_ulong pc, uint32_t opcode, void* cpu_ptr)
 {
    /* PC altering instructions will skip the commit helper. */
+   CPUState* cpu_state = (CPUState*) cpu_ptr;
    if (skipped_commit) {
       if (e_v_commit()) {
          riscv_raise_exception(env, EXCP_DEBUG, GETPC());
@@ -28,6 +30,7 @@ void helper_validator_validate(CPURISCVState *env, target_ulong pc, uint32_t opc
    skipped_commit = true;
 
    policy_validator_hack_env = env;
+   policy_validator_hack_cpu_state = cpu_state;
    if (!e_v_validate((uint64_t)pc, opcode)) {
       char *msg = g_malloc(1024);
       policy_validator_violation_msg(msg, 1024);

--- a/target/riscv/helper.h
+++ b/target/riscv/helper.h
@@ -1,5 +1,5 @@
 #ifdef ENABLE_VALIDATOR
-DEF_HELPER_3(validator_validate, void, env, tl, i32)
+DEF_HELPER_4(validator_validate, void, env, tl, i32, ptr)
 DEF_HELPER_1(validator_commit, void, env)
 #endif
 

--- a/target/riscv/translate.c
+++ b/target/riscv/translate.c
@@ -815,13 +815,15 @@ static void riscv_tr_translate_insn(DisasContextBase *dcbase, CPUState *cpu)
     */
 
     /* Validate */
-    uint32_t pc = ctx->base.pc_next;
+    target_ulong pc = ctx->base.pc_next;
     if (policy_validator_enabled()) {
        if (!(pc >= 0x1000 && pc < 0x2000)) { //reset ROM
           TCGv_i32 opcode = tcg_const_i32(ctx->opcode);
 
           tcg_gen_movi_tl(cpu_pc, pc);
-          gen_helper_validator_validate(cpu_env, cpu_pc, opcode);
+          TCGv_ptr cpu_state_ptr = tcg_const_ptr(cpu);
+          gen_helper_validator_validate(cpu_env, cpu_pc, opcode, cpu_state_ptr);
+          tcg_temp_free_ptr(cpu_state_ptr);
        }
     }
 #endif


### PR DESCRIPTION
When no physical address is found, return the virtual address (this can happen immediately after virtual memory is enabled).